### PR TITLE
Docker tool path update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,9 @@ RUN export JAVA_HOME
 
 # copy Fragpipe dependencies 
 
-COPY MSFragger-4.3.jar /fragpipe_bin/fragPipe-23.1/fragpipe/tools/MSFragger-4.3.jar 
-COPY diaTracer-1.3.3.jar /fragpipe_bin/fragPipe-23.1/fragpipe/tools/diaTracer-1.3.3.jar
-COPY IonQuant-1.11.11.jar /fragpipe_bin/fragPipe-23.1/fragpipe/tools/IonQuant-1.11.11.jar
+COPY MSFragger-4.3.jar /fragpipe_bin/fragPipe-23.1/fragpipe-23.1/tools/MSFragger-4.3.jar 
+COPY diaTracer-1.3.3.jar /fragpipe_bin/fragPipe-23.1/fragpipe-23.1/tools/diaTracer-1.3.3.jar
+COPY IonQuant-1.11.11.jar /fragpipe_bin/fragPipe-23.1/fragpipe-23.1/tools/IonQuant-1.11.11.jar
 
 WORKDIR /rocker-build/
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What scientific question is your analysis addressing?

Copies DiaTracer, MSFragger, and IonQuant jar files to same tool dir as other fragpipe dependencies

#### What was your approach?



#### What GitHub issue does your pull request address?



### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?

1. Pull latest docker image following instructions in README and bash within container. Then confirm the following tools are in directory `/fragpipe_bin/fragPipe-23.1/fragpipe-23.1/tools/`:

```
diaTracer-1.3.3.jar
IonQuant-1.11.11.jar
MSFragger-4.3.jar
```

#### Is there anything that you want to discuss further?



#### Is the analysis in a mature enough form that the resulting figure(s) and/or table(s) are ready for review?



### Results

#### What types of results are included (e.g., table, figure)?



#### What is your summary of the results?



#### Reproducibility Checklist

<!-- Check all those that apply or remove this section if it is not applicable.-->

- [ ] The dependencies required to run the code in this pull request have been added to the project Dockerfile.

#### Documentation Checklist

- [ ] This analysis module has a `README` and it is up to date.
- [ ] The analytical code is documented and contains comments.
